### PR TITLE
change string to byte encoded array for TON payload; allow delete of audiences

### DIFF
--- a/home/requests.py
+++ b/home/requests.py
@@ -40,7 +40,7 @@ class GNIP:
         return GnipSearchAPI(settings.GNIP_USERNAME,
                           settings.GNIP_PASSWORD,
                           settings.GNIP_SEARCH_ENDPOINT,
-                          paged=True)
+                          paged=False)
 
     def get_timeline(self):
         """

--- a/home/views.py
+++ b/home/views.py
@@ -96,7 +96,8 @@ def query_tweets(request):
                              twitter_consumer_secret=settings.SOCIAL_AUTH_TWITTER_SECRET,
                              access_token=settings.TWITTER_ACCESS_TOKEN,
                              access_token_secret=settings.TWITTER_ACCESS_TOKEN_SECRET)
-        ton_response = ton_request.upload_data(payload=output.getvalue())
+        bytes = output.getvalue()
+        ton_response = ton_request.upload_data(payload=bytes.encode('utf-16be'))
         output.close()
         location = ton_response['location']
         response = HttpResponse(json.dumps({"location": location, "query": query}), content_type="application/json")

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -428,6 +428,10 @@ var Page = {
 					 // Let the user know that Audience Has been Created
 					 // Display some div
 					 NProgress.done();
+					 
+					 // redirect to audience API
+					 window.location = "/ads/audiences";
+					 
 				 },
 				 error : function(xhr, errorType, exception) {
 					 Page.handleError(xhr, errorType, exception);

--- a/templates/audiences.html
+++ b/templates/audiences.html
@@ -14,7 +14,7 @@
       <tr>
         <th>Audience Bucket</th>
         <th>Search Query</th>
-        <th></th>
+        <th>Actions</th>
       </tr>
     </thead>
     <tbody class="table-data">
@@ -22,23 +22,64 @@
   </table>
 </div>
 <script>
-$(document).ready(function () {
+
+function displayAudiences(){
+
+  $(".table-data").html("");
+
   var audienceList = localStorage.getItem("audienceList");
   if (audienceList != null) {
+  
     var json_list = JSON.parse(audienceList);
     for (var i=0; i < json_list.length; i++) {
-        var item = json_list[i]
-        tr = $('<tr/>');
-        tr.append("<td>" + item["location"] + "</td>");
-        tr.append("<td>" + item["query"] + "</td>");
-        tr.append("<td><button class='ta btn btn-danger' data-id='" + item['location'] + "'>Target Audience</button>")
-        $(".table").append(tr);
+        var item = json_list[i];
+        
+        if (item){
+          tr = $('<tr/>');
+          tr.append("<td>" + item["location"] + "</td>");
+          tr.append("<td>" + item["query"] + "</td>");
+          td2 = $('<td/>');
+          td2.append("<button class='ta btn btn-sm btn-danger' data-id='" + item['location'] + "'>Target Audience</button> ")
+          td2.append("<button class='ta-del btn btn-sm btn-primary' data-id='" + item['location'] + "'>Delete</button>")
+          tr.append(td2)
+          $(".table").append(tr);
+        }
     }
   }
-  $(".ta").on("click", function(){
+
+}
+
+$(document).ready(function () {
+
+  displayAudiences();
+
+  $(document).on("click", ".ta", function(){
     var bucket_location = $(this).data("id");
     // Set bucket to local storage and then send the user a modal
     localStorage.setItem("selected_bucket") = bucket_location
+  });
+  
+  $(document).on("click", ".ta-del", function(){
+    var bucket_location = $(this).data("id");
+
+    var audienceList = localStorage.getItem("audienceList");
+    if (audienceList != null) {
+    
+      var json_list = JSON.parse(audienceList);
+
+      for (var i=0; i < json_list.length; i++) {
+        var item = json_list[i]
+        if (!item || item["location"] == bucket_location){
+            delete json_list[i]
+        }
+      }
+      
+      localStorage.setItem("audienceList", JSON.stringify(json_list))
+      
+    }
+    
+    displayAudiences();
+
   });
 });
 


### PR DESCRIPTION
was getting byte encoded issues previously. 

id:twitter.com:3307510346
id:twitter.com:2710480771
id:twitter.com:2639187241
id:twitter.com:2639187241
id:twitter.com:3413384299
id:twitter.com:3413384299
id:twitter.com:3090441217
id:twitter.com:443162144
id:twitter.com:1058413002
id:twitter.com:4690966945

Now works and returns a proper JSON response:

{'x-rate-limit-remaining': '48', 'x-response-time': '32', 'content-length': '0', 'x-content-type-options': 'nosniff', 'x-connection-hash': '245949b39a29155c62e705679d93d5a6', 'set-cookie': 'guest_id=v1%3A145326498503073011; Domain=.twitter.com; Path=/; Expires=Fri, 19-Jan-2018 04:43:05 UTC', 'strict-transport-security': 'max-age=631138519', 'x-tsa-request-body-time': '1', 'server': 'tsa_a', 'location': '/1.1/ton/data/ta_partner/54256387/kScQhNd6D7bY24E', 'date': 'Wed, 20 Jan 2016 04:43:05 GMT', 'x-rate-limit-limit': '50', 'content-type': 'application/octet-stream', 'x-rate-limit-reset': '1453265854'}
