### PR TITLE
Harden targeting criteria POST protocol

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,53 @@
+name: Check
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  protocol:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12", "3.14"]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements-review.txt
+      - run: python -m pip install --disable-pip-version-check -r requirements-review.txt
+      - run: python -m pip check
+      - run: make check PYTHON=python
+
+  mutations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-review.txt
+      - run: python -m pip install --disable-pip-version-check -r requirements-review.txt
+      - run: make mutations PYTHON=python
+
+  changed-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,25 @@
+name: CodeQL
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["actions", "javascript-typescript", "python"]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: ${{ matrix.language }}
+      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 app/settings_my.py
 fabfile.py
 db.sqlite3
+.review/
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+PYTHON ?= python3
+ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+.PHONY: check mutations
+
+check:
+	cd "$(ROOT)" && $(PYTHON) -m unittest discover -s tests -p 'test_*.py'
+	cd "$(ROOT)" && $(PYTHON) -m py_compile home/ads_protocol.py tests/test_ads_protocol.py tests/test_integration_contracts.py
+	cd "$(ROOT)" && git diff --check
+
+mutations:
+	cd "$(ROOT)" && $(PYTHON) scripts/test_mutations.py

--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 Audience Creation and Ad Targeting using Twitter Data (Gnip) and Ads API
 =================
 
+Targeting writes use a CSRF-protected browser POST and one OAuth 1.0a provider
+POST to `https://ads-api.x.com/12`. The provider request is UTF-8 form encoded,
+does not follow redirects or retry, has bounded timeouts, and accepts at most
+64 KiB of JSON response data. After a timeout or connection failure, inspect
+the Ads account before retrying because the outcome is unknown and the API does
+not expose an idempotency key for this operation.
+
 This sample uses GNIP full archive search to iteratively create audiences for ad targeting on Twitter. It uses the Full Archive Search API to determine volume of tweets about a topic, uploads them
 as an audience via the TON API, and then allows creation of new Campaigns against that audience.
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -148,6 +148,9 @@ SOCIAL_AUTH_TWITTER_SECRET = environ.get('CONSUMER_SECRET')         # Twitter AP
 
 TWITTER_ACCESS_TOKEN = environ.get('ACCESS_TOKEN')                  # Twitter API Access Token
 TWITTER_ACCESS_TOKEN_SECRET = environ.get('ACCESS_TOKEN_SECRET')    # Twitter API Access Secret
+TWITTER_ADS_API_BASE_URL = environ.get(
+    'TWITTER_ADS_API_BASE_URL',
+    'https://ads-api.x.com/12')
 
 GNIP_USERNAME = environ.get('GNIP_USERNAME')                         # Gnip username
 GNIP_PASSWORD = environ.get('GNIP_PASSWORD')                         # Gnip password

--- a/home/ads_protocol.py
+++ b/home/ads_protocol.py
@@ -1,0 +1,234 @@
+from __future__ import unicode_literals
+
+import json
+import re
+
+import requests
+from requests.adapters import HTTPAdapter
+from requests_oauthlib import OAuth1Session
+try:
+    from urllib.parse import parse_qs, urlsplit
+except ImportError:
+    from urlparse import parse_qs, urlsplit
+
+try:
+    string_types = (basestring,)
+except NameError:
+    string_types = (str,)
+
+
+MAX_REQUEST_BYTES = 4 * 1024
+MAX_RESPONSE_BYTES = 64 * 1024
+MAX_TARGETING_VALUE_BYTES = 1024
+_IDENTIFIER = re.compile(r"^[A-Za-z0-9]{1,64}$")
+_TARGETING_TYPE = re.compile(r"^[A-Z][A-Z0-9_]{1,63}$")
+
+
+class AdsProtocolError(Exception):
+    def __init__(self, message, outcome_unknown=False):
+        super(AdsProtocolError, self).__init__(message)
+        self.outcome_unknown = outcome_unknown
+
+
+def _validate_identifier(name, value):
+    if not isinstance(value, string_types) or not _IDENTIFIER.match(value):
+        raise AdsProtocolError("%s is invalid" % name)
+    return value
+
+
+def _validate_targeting_type(value):
+    if not isinstance(value, string_types) or not _TARGETING_TYPE.match(value):
+        raise AdsProtocolError("targeting_type is invalid")
+    return value
+
+
+def _validate_targeting_value(value):
+    if not isinstance(value, string_types) or not value or "\x00" in value:
+        raise AdsProtocolError("targeting_value is invalid")
+    encoded = value.encode("utf-8")
+    if len(encoded) > MAX_TARGETING_VALUE_BYTES:
+        raise AdsProtocolError("targeting_value is too large")
+    return value
+
+
+def _validated_base_url(base_url, allow_loopback_http):
+    if not isinstance(base_url, string_types):
+        raise AdsProtocolError("Ads API base URL is invalid")
+    parsed = urlsplit(base_url.rstrip("/"))
+    loopback = parsed.hostname in ("127.0.0.1", "::1", "localhost")
+    if parsed.scheme != "https" and not (allow_loopback_http and parsed.scheme == "http" and loopback):
+        raise AdsProtocolError("Ads API base URL must use HTTPS")
+    if not parsed.hostname or parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise AdsProtocolError("Ads API base URL is invalid")
+    return base_url.rstrip("/")
+
+
+class TwitterAdsTargetingClient(object):
+    def __init__(self, consumer_key, consumer_secret, access_token,
+                 access_token_secret, base_url,
+                 connect_timeout=3.05, read_timeout=10.0,
+                 allow_loopback_http=False):
+        credentials = (consumer_key, consumer_secret, access_token, access_token_secret)
+        if not all(isinstance(value, string_types) and value for value in credentials):
+            raise AdsProtocolError("Twitter Ads credentials are incomplete")
+        if connect_timeout <= 0 or read_timeout <= 0:
+            raise AdsProtocolError("Twitter Ads timeouts must be positive")
+
+        self._base_url = _validated_base_url(base_url, allow_loopback_http)
+        self._timeout = (connect_timeout, read_timeout)
+        self._session = OAuth1Session(
+            consumer_key,
+            client_secret=consumer_secret,
+            resource_owner_key=access_token,
+            resource_owner_secret=access_token_secret,
+        )
+        self._session.mount("http://", HTTPAdapter(max_retries=0))
+        self._session.mount("https://", HTTPAdapter(max_retries=0))
+
+    def create_targeting_criterion(self, account_id, line_item_id,
+                                   targeting_type, targeting_value):
+        account_id = _validate_identifier("account_id", account_id)
+        form = {
+            "line_item_id": _validate_identifier("line_item_id", line_item_id),
+            "targeting_type": _validate_targeting_type(targeting_type),
+            "targeting_value": _validate_targeting_value(targeting_value),
+        }
+        url = "%s/accounts/%s/targeting_criteria" % (self._base_url, account_id)
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+            "User-Agent": "data-ads-demo-targeting/1",
+        }
+
+        try:
+            response = self._session.post(
+                url,
+                data=form,
+                headers=headers,
+                allow_redirects=False,
+                timeout=self._timeout,
+                stream=True,
+            )
+        except requests.Timeout:
+            raise AdsProtocolError(
+                "Twitter Ads request timed out; outcome is unknown",
+                outcome_unknown=True,
+            )
+        except requests.RequestException:
+            raise AdsProtocolError(
+                "Twitter Ads request failed; outcome is unknown",
+                outcome_unknown=True,
+            )
+
+        try:
+            if 300 <= response.status_code < 400:
+                raise AdsProtocolError("Twitter Ads redirect was rejected")
+
+            content_type = response.headers.get("Content-Type", "").split(";", 1)[0].strip().lower()
+            if content_type != "application/json":
+                raise AdsProtocolError("Twitter Ads response was not JSON")
+            content_length = response.headers.get("Content-Length")
+            if content_length:
+                try:
+                    if int(content_length) > MAX_RESPONSE_BYTES:
+                        raise AdsProtocolError("Twitter Ads response is too large")
+                except ValueError:
+                    raise AdsProtocolError("Twitter Ads response length is invalid")
+
+            body = bytearray()
+            try:
+                for chunk in response.iter_content(chunk_size=8192):
+                    body.extend(chunk)
+                    if len(body) > MAX_RESPONSE_BYTES:
+                        raise AdsProtocolError("Twitter Ads response is too large")
+            except requests.RequestException:
+                raise AdsProtocolError("Twitter Ads response was incomplete")
+
+            try:
+                payload = json.loads(bytes(body).decode("utf-8"))
+            except (UnicodeDecodeError, ValueError):
+                raise AdsProtocolError("Twitter Ads response contained invalid JSON")
+
+            if not isinstance(payload, dict):
+                raise AdsProtocolError("Twitter Ads response schema is invalid")
+            if response.status_code < 200 or response.status_code >= 300:
+                raise AdsProtocolError(_safe_provider_error(payload))
+            data = payload.get("data")
+            if not isinstance(data, dict):
+                raise AdsProtocolError("Twitter Ads response schema is invalid")
+            return data
+        finally:
+            response.close()
+
+
+def _safe_provider_error(payload):
+    errors = payload.get("errors")
+    if not isinstance(errors, list) or not errors:
+        return "Twitter Ads rejected the request"
+    first = errors[0]
+    if not isinstance(first, dict):
+        return "Twitter Ads rejected the request"
+    message = first.get("message")
+    if not isinstance(message, string_types):
+        return "Twitter Ads rejected the request"
+    message = "".join(character for character in message if character >= " " and character != "\x7f")
+    message = message[:256].strip()
+    return message or "Twitter Ads rejected the request"
+
+
+def parse_targeting_form(method, content_type, body):
+    if method != "POST":
+        raise AdsProtocolError("targeting creation requires POST")
+    if not isinstance(content_type, string_types):
+        raise AdsProtocolError("targeting request content type is invalid")
+    media_type, separator, parameters = content_type.partition(";")
+    if media_type.strip().lower() != "application/x-www-form-urlencoded":
+        raise AdsProtocolError("targeting request must be form encoded")
+    if separator:
+        parameter = parameters.strip().lower().replace(" ", "")
+        if parameter != "charset=utf-8":
+            raise AdsProtocolError("targeting request charset must be UTF-8")
+    if not isinstance(body, bytes) or not body or len(body) > MAX_REQUEST_BYTES:
+        raise AdsProtocolError("targeting request body is invalid")
+    if re.search(br"%(?![0-9A-Fa-f]{2})", body):
+        raise AdsProtocolError("targeting request encoding is invalid")
+    try:
+        decoded = body.decode("ascii")
+        parsed = parse_qs(
+            decoded,
+            keep_blank_values=True,
+            strict_parsing=True,
+            encoding="utf-8",
+            errors="strict",
+        )
+    except (UnicodeDecodeError, ValueError, TypeError):
+        raise AdsProtocolError("targeting request encoding is invalid")
+
+    expected = set(("account_id", "line_item_id", "targeting_type", "targeting_value"))
+    if set(parsed) != expected or any(len(values) != 1 for values in parsed.values()):
+        raise AdsProtocolError("targeting request schema is invalid")
+    result = dict((name, values[0]) for name, values in parsed.items())
+    _validate_identifier("account_id", result["account_id"])
+    _validate_identifier("line_item_id", result["line_item_id"])
+    _validate_targeting_type(result["targeting_type"])
+    _validate_targeting_value(result["targeting_value"])
+    return result
+
+
+def process_targeting_request(method, content_type, body, client_factory):
+    try:
+        values = parse_targeting_form(method, content_type, body)
+    except AdsProtocolError:
+        return 400, {"valid": False, "error": "invalid_request"}
+
+    try:
+        data = client_factory().create_targeting_criterion(**values)
+    except AdsProtocolError as error:
+        if error.outcome_unknown:
+            return 504, {"valid": False, "error": "provider_outcome_unknown"}
+        return 502, {"valid": False, "error": "provider_request_failed"}
+
+    identifier = data.get("id") if isinstance(data, dict) else None
+    if not isinstance(identifier, string_types) or not _IDENTIFIER.match(identifier):
+        return 502, {"valid": False, "error": "provider_response_invalid"}
+    return 201, {"valid": True, "id": identifier}

--- a/home/lineitems.py
+++ b/home/lineitems.py
@@ -5,46 +5,46 @@ from django.contrib.auth.decorators import login_required, user_passes_test
 from django.contrib.auth import logout as auth_logout
 from django.conf import settings
 from twitter_ads.client import Client
-from twitter_ads.campaign import TargetingCriteria, LineItem
+from twitter_ads.campaign import LineItem
 from twitter_ads.enum import PRODUCT, PLACEMENT, OBJECTIVE
 from twitter_ads.error import Error
+
+from home.ads_protocol import (
+    MAX_REQUEST_BYTES,
+    TwitterAdsTargetingClient,
+    process_targeting_request)
 
 
 @login_required
 def new_targeting(request):
     """
-    Creates a new
+    Creates a targeting criterion through a bounded, single-attempt POST.
     """
-    line_item_id = request.GET.get("line_item_id", "")
-    account_id = request.GET.get("account_id", "")
-    targeting_value = request.GET.get("targeting_value")
-    targeting_type = "BEHAVIOR_EXPANDED"
-    json_data = {}
-    try:
-        client = Client(
+    def client_factory():
+        return TwitterAdsTargetingClient(
             settings.SOCIAL_AUTH_TWITTER_KEY,
             settings.SOCIAL_AUTH_TWITTER_SECRET,
             settings.TWITTER_ACCESS_TOKEN,
-            settings.TWITTER_ACCESS_TOKEN_SECRET)
-        account = client.accounts(account_id)
-        targeting_criteria = TargetingCriteria(account)
-        targeting_criteria.line_item_id = line_item_id
-        targeting_criteria.targeting_type = targeting_type
-        targeting_criteria.targeting_value = targeting_value
-        if targeting_value == "TAILORED_AUDIENCE":
-            targeting_criteria.tailored_audience_type = "FLEXIBLE"
-        targeting_criteria.save()
-        json_data = {
-            "valid": True,
-            "account_id": account_id,
-            "line_item_id": line_item_id,
-            "targeting_value": targeting_value}
-    except Error as e:
-        json_data["response"] = e.details
-        json_data["valid"] = False
-        # passing to push the json_data to the browser
-        pass
-    return HttpResponse(json.dumps(json_data), content_type="application/json")
+            settings.TWITTER_ACCESS_TOKEN_SECRET,
+            base_url=settings.TWITTER_ADS_API_BASE_URL)
+
+    try:
+        content_length = int(request.META.get("CONTENT_LENGTH", ""))
+    except (TypeError, ValueError):
+        content_length = 0
+    if content_length <= 0 or content_length > MAX_REQUEST_BYTES:
+        status = 400
+        json_data = {"valid": False, "error": "invalid_request"}
+    else:
+        status, json_data = process_targeting_request(
+            request.method,
+            request.META.get("CONTENT_TYPE", ""),
+            request.body,
+            client_factory)
+    return HttpResponse(
+        json.dumps(json_data),
+        content_type="application/json",
+        status=status)
 
 
 @login_required

--- a/home/views.py
+++ b/home/views.py
@@ -16,6 +16,7 @@ from django.shortcuts import *
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.contrib.auth import logout as auth_logout
 from django.conf import settings
+from django.views.decorators.csrf import ensure_csrf_cookie
 
 MAX_AGE = getattr(settings, 'CACHE_CONTROL_MAX_AGE', 2592000)
 
@@ -34,6 +35,7 @@ def login(request):
 
 
 @login_required
+@ensure_csrf_cookie
 def home(request):
     """
     Returns home page for given request

--- a/requirements-review.txt
+++ b/requirements-review.txt
@@ -1,0 +1,2 @@
+requests==2.32.5
+requests-oauthlib==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Django==1.9.1
 dj-database-url==0.3.0
 gunicorn==19.1.1
 python-social-auth
+requests-oauthlib
 Fabric==1.7.0
 gnacs
 -e git://github.com/DrSkippy/Simple-n-grams.git@bbfd782614b39e2d0a1bc01fc6a75cc5df235e3e#egg=Simple-n-grams

--- a/scripts/test_mutations.py
+++ b/scripts/test_mutations.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MUTATIONS = [
+    ("home/ads_protocol.py", "allow_redirects=False", "allow_redirects=True"),
+    ("home/ads_protocol.py", "HTTPAdapter(max_retries=0)", "HTTPAdapter(max_retries=1)"),
+    ("home/ads_protocol.py", "timeout=self._timeout", "timeout=None"),
+    ("home/ads_protocol.py", "data=form", "params=form"),
+    (
+        "home/ads_protocol.py",
+        'if len(body) > MAX_RESPONSE_BYTES:',
+        'if False and len(body) > MAX_RESPONSE_BYTES:',
+    ),
+    ("static/js/ads.js", 'type: "POST"', 'type: "GET"'),
+    ("static/js/ads.js", "line_item_id: line_item_id", "line_item_id: campaign_id"),
+    (
+        "static/js/ads.js",
+        "if (targetingWriteInFlight || payloads.length === 0)",
+        "if (payloads.length === 0)",
+    ),
+]
+
+
+def copy_fixture(destination):
+    for source in ("home", "tests"):
+        shutil.copytree(ROOT / source, destination / source)
+    (destination / "static" / "js").mkdir(parents=True)
+    shutil.copy2(ROOT / "static" / "js" / "ads.js", destination / "static" / "js" / "ads.js")
+    (destination / "app").mkdir()
+    shutil.copy2(ROOT / "app" / "settings.py", destination / "app" / "settings.py")
+    shutil.copy2(ROOT / "requirements.txt", destination / "requirements.txt")
+
+
+def main():
+    failures = []
+    for index, (relative_path, original, replacement) in enumerate(MUTATIONS, start=1):
+        with tempfile.TemporaryDirectory(prefix="data-ads-mutation-") as temporary:
+            destination = Path(temporary)
+            copy_fixture(destination)
+            target = destination / relative_path
+            source = target.read_text(encoding="utf-8")
+            if original not in source:
+                failures.append("mutation %d did not match" % index)
+                continue
+            target.write_text(source.replace(original, replacement), encoding="utf-8")
+            result = subprocess.run(
+                [sys.executable, "-m", "unittest", "discover", "-s", "tests", "-p", "test_*.py"],
+                cwd=str(destination),
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            if result.returncode == 0:
+                failures.append("mutation %d survived: %s" % (index, relative_path))
+
+    if failures:
+        for failure in failures:
+            print(failure, file=sys.stderr)
+        return 1
+    print("killed %d hostile mutations" % len(MUTATIONS))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/static/js/ads.js
+++ b/static/js/ads.js
@@ -1,4 +1,61 @@
 // Setup
+var targetingWriteInFlight = false;
+
+function getCookie(name) {
+  var cookies = document.cookie ? document.cookie.split(";") : [];
+  for (var index = 0; index < cookies.length; index++) {
+    var cookie = $.trim(cookies[index]);
+    if (cookie.substring(0, name.length + 1) === name + "=") {
+      return decodeURIComponent(cookie.substring(name.length + 1));
+    }
+  }
+  return "";
+}
+
+function submitTargeting(payloads) {
+  if (targetingWriteInFlight || payloads.length === 0) {
+    return;
+  }
+
+  targetingWriteInFlight = true;
+  $(".ads-add-targeting").prop("disabled", true);
+
+  function finish() {
+    targetingWriteInFlight = false;
+    $(".ads-add-targeting").prop("disabled", false);
+  }
+
+  function submitAt(index) {
+    if (index >= payloads.length) {
+      finish();
+      return;
+    }
+    $.ajax({
+      url: "../../ads/api/targeting/new",
+      type: "POST",
+      dataType: "json",
+      data: payloads[index],
+      headers: {"X-CSRFToken": getCookie("csrftoken")}
+    }).done(function(json) {
+      if (json.valid === true) {
+        submitAt(index + 1);
+      } else {
+        $(".error").show();
+        $(".error-details").text("Targeting request was rejected.");
+        finish();
+      }
+    }).fail(function() {
+      $(".error").show();
+      $(".error-details").text(
+        "Targeting outcome is unknown. Inspect the Ads account before retrying."
+      );
+      finish();
+    });
+  }
+
+  submitAt(0);
+}
+
 function setup(){
   getAccounts();
   // Only show the accounts list.
@@ -76,8 +133,6 @@ function mapBucket(account_id, identifier, input_file_path){
   var encodedData = window.btoa(input_file_path)
   $.getJSON("../../ads/api/audiences/change?account_id=" + account_id + "&id=" + identifier + "&input_file_path=" + encodedData,
   function (json) {
-    //console.log(json);
-
     if (json["error"]) {
       console.log("http request failed for mapping the bucket to the input_file_path");
       return false;
@@ -128,8 +183,6 @@ function getLineItems(account_id, campaign_id){
       $(".ads-lineitems").hide();
       $(".ads-api-lineitem").remove();
       $(".ads-targeting").show();
-      getTargetingCriteria(account_id, campaign_id, $(this).data("id"));
-
       if (page == "AUDIENCE") {
         setTATargeting(account_id, campaign_id, $(this).data("id"));
       } else {
@@ -143,29 +196,18 @@ function getLineItems(account_id, campaign_id){
 
 // set TargetingCriteria
 function setTATargeting(account_id, campaign_id, line_item_id){
-  // for each value send http request to create a targeting criteria
-  $.getJSON("../../ads/api/targeting/new?account_id=" + account_id + "&line_item_id=" + line_item_id + "&targeting_value=" +  localStorage.getItem("selected_ta_list_id") + "&targeting_type=TAILORED_AUDIENCE",
-  function (json) {
-    if (json['valid'] == true){
-      //everything is great
-      console.log("no error");
-      console.log(json);
-      //$('#adsModal').hide();
-      //location.reload();
-
-    } else {
-      // make things happen
-      console.log("error");
-      console.log(error);
-      $(".error").show();
-      $(".error-details").text(json);
-    }
-  });
+  submitTargeting([{
+    account_id: account_id,
+    line_item_id: line_item_id,
+    targeting_value: localStorage.getItem("selected_ta_list_id"),
+    targeting_type: "CUSTOM_AUDIENCE"
+  }]);
 }
 
 // Get the targeting criteria to a dropdown to target
 function getTargetingCriteria(account_id, campaign_id, line_item_id){
-  $(".ads-add-targeting").click(function(e) {
+  $(".ads-add-targeting").off("click.targeting").on("click.targeting", function(e) {
+    e.preventDefault();
     setTargetingCriteria(account_id, campaign_id, line_item_id);
   });
 
@@ -175,7 +217,6 @@ function getTargetingCriteria(account_id, campaign_id, line_item_id){
 
 
   $(checkedVals).each(function( index ) {
-    console.log(checkedVals);
     $(".ads-targeting-list").append("<li>" + checkedVals[index] + "</li>");
   });
 
@@ -183,25 +224,18 @@ function getTargetingCriteria(account_id, campaign_id, line_item_id){
 
 // set TargetingCriteria
 function setTargetingCriteria(account_id, campaign_id, line_item_id){
-  //
   var checkedVals = $('.term:checkbox:checked').map(function() {
     return this.value;
   }).get();
-
-  // for each value send http request to create a targeting criteria
-  $(checkedVals).each(function( index ) {
-    var targeting_value = checkedVals[index];
-    $.getJSON("../../ads/api/targeting/new?account_id=" + account_id + "&line_item_id=" + campaign_id + "&targeting_value=" + targeting_value,
-    function (json) {
-      if (json['valid'] == true) {
-        // Ready
-        console.log("ready");
-      } else {
-        // Not Valid
-        console.log("not ready");
-      }
-    });
+  var payloads = $.map(checkedVals, function(targeting_value) {
+    return {
+      account_id: account_id,
+      line_item_id: line_item_id,
+      targeting_value: targeting_value,
+      targeting_type: "PHRASE_KEYWORD"
+    };
   });
+  submitTargeting(payloads);
 }
 
 // Ads-Modal on close

--- a/tests/test_ads_protocol.py
+++ b/tests/test_ads_protocol.py
@@ -1,0 +1,347 @@
+import json
+import socket
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlsplit
+from unittest.mock import patch
+
+from home.ads_protocol import (
+    MAX_REQUEST_BYTES,
+    MAX_RESPONSE_BYTES,
+    AdsProtocolError,
+    TwitterAdsTargetingClient,
+    parse_targeting_form,
+    process_targeting_request,
+)
+
+
+class FakeAdsHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    response_status = 201
+    response_headers = {"Content-Type": "application/json; charset=utf-8"}
+    response_body = json.dumps({"data": {"id": "criterion-1"}}).encode("utf-8")
+    response_delay = 0
+    omit_content_length = False
+    requests = []
+
+    def do_POST(self):
+        content_length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(content_length)
+        self.__class__.requests.append(
+            {
+                "path": self.path,
+                "headers": dict(self.headers),
+                "body": body,
+            }
+        )
+        if self.__class__.response_delay:
+            time.sleep(self.__class__.response_delay)
+        self.send_response(self.__class__.response_status)
+        headers = dict(self.__class__.response_headers)
+        if not self.__class__.omit_content_length:
+            headers.setdefault("Content-Length", str(len(self.__class__.response_body)))
+        headers.setdefault("Connection", "close")
+        for name, value in headers.items():
+            self.send_header(name, value)
+        self.end_headers()
+        try:
+            self.wfile.write(self.__class__.response_body)
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+    def log_message(self, format, *args):
+        return
+
+
+class FakeAdsServer:
+    def __enter__(self):
+        FakeAdsHandler.response_status = 201
+        FakeAdsHandler.response_headers = {"Content-Type": "application/json; charset=utf-8"}
+        FakeAdsHandler.response_body = json.dumps({"data": {"id": "criterion-1"}}).encode("utf-8")
+        FakeAdsHandler.response_delay = 0
+        FakeAdsHandler.omit_content_length = False
+        FakeAdsHandler.requests = []
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), FakeAdsHandler)
+        self.thread = threading.Thread(target=self.server.serve_forever)
+        self.thread.daemon = True
+        self.thread.start()
+        host, port = self.server.server_address
+        self.base_url = "http://%s:%d/12" % (host, port)
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+
+
+class TwitterAdsTargetingClientTests(unittest.TestCase):
+    def make_client(self, base_url, **overrides):
+        options = {
+            "consumer_key": "consumer-key",
+            "consumer_secret": "consumer-secret",
+            "access_token": "access-token",
+            "access_token_secret": "access-token-secret",
+            "base_url": base_url,
+            "connect_timeout": 0.25,
+            "read_timeout": 0.25,
+            "allow_loopback_http": True,
+        }
+        options.update(overrides)
+        return TwitterAdsTargetingClient(**options)
+
+    def test_posts_utf8_form_body_and_oauth_header_without_query_parameters(self):
+        with FakeAdsServer() as server:
+            response = self.make_client(server.base_url).create_targeting_criterion(
+                account_id="18ce54d4x5t",
+                line_item_id="8u94t",
+                targeting_type="PHRASE_KEYWORD",
+                targeting_value="grumpy cat ☕",
+            )
+
+        self.assertEqual({"id": "criterion-1"}, response)
+        self.assertEqual(1, len(FakeAdsHandler.requests))
+        request = FakeAdsHandler.requests[0]
+        self.assertEqual(
+            "/12/accounts/18ce54d4x5t/targeting_criteria",
+            urlsplit(request["path"]).path,
+        )
+        self.assertEqual("", urlsplit(request["path"]).query)
+        self.assertEqual(
+            {
+                "line_item_id": ["8u94t"],
+                "targeting_type": ["PHRASE_KEYWORD"],
+                "targeting_value": ["grumpy cat ☕"],
+            },
+            parse_qs(request["body"].decode("utf-8"), strict_parsing=True),
+        )
+        self.assertEqual("application/x-www-form-urlencoded", request["headers"]["Content-Type"])
+        authorization = request["headers"].get("Authorization", "")
+        self.assertTrue(authorization.startswith("OAuth "))
+        self.assertIn('oauth_signature="', authorization)
+        self.assertNotIn("consumer-secret", request["body"].decode("utf-8"))
+        self.assertNotIn("access-token-secret", request["body"].decode("utf-8"))
+
+    def test_oauth_signature_changes_when_only_signed_form_body_changes(self):
+        with FakeAdsServer() as server:
+            client = self.make_client(server.base_url)
+            with patch("oauthlib.oauth1.rfc5849.generate_nonce", return_value="fixednonce"), patch(
+                "oauthlib.oauth1.rfc5849.generate_timestamp", return_value="1700000000"
+            ):
+                client.create_targeting_criterion("account", "line", "LOCATION", "first")
+                client.create_targeting_criterion("account", "line", "LOCATION", "second")
+
+        first = FakeAdsHandler.requests[0]["headers"]["Authorization"]
+        second = FakeAdsHandler.requests[1]["headers"]["Authorization"]
+        self.assertNotEqual(first, second)
+        self.assertIn('oauth_nonce="fixednonce"', first)
+        self.assertIn('oauth_timestamp="1700000000"', first)
+
+    def test_rejects_redirect_without_forwarding_credentials(self):
+        with FakeAdsServer() as server:
+            FakeAdsHandler.response_status = 307
+            FakeAdsHandler.response_headers = {
+                "Content-Type": "text/plain",
+                "Location": "http://127.0.0.1:1/credential-sink",
+            }
+            FakeAdsHandler.response_body = b"redirect"
+            with self.assertRaisesRegex(AdsProtocolError, "redirect"):
+                self.make_client(server.base_url).create_targeting_criterion(
+                    "18ce54d4x5t", "8u94t", "LOCATION", "123"
+                )
+        self.assertEqual(1, len(FakeAdsHandler.requests))
+
+    def test_does_not_retry_ambiguous_server_failure(self):
+        with FakeAdsServer() as server:
+            FakeAdsHandler.response_status = 503
+            FakeAdsHandler.response_body = json.dumps(
+                {"errors": [{"message": "temporarily unavailable", "code": "UNAVAILABLE"}]}
+            ).encode("utf-8")
+            with self.assertRaisesRegex(AdsProtocolError, "temporarily unavailable"):
+                self.make_client(server.base_url).create_targeting_criterion(
+                    "18ce54d4x5t", "8u94t", "LOCATION", "123"
+                )
+        self.assertEqual(1, len(FakeAdsHandler.requests))
+
+    def test_enforces_read_timeout(self):
+        with FakeAdsServer() as server:
+            FakeAdsHandler.response_delay = 0.2
+            with self.assertRaisesRegex(AdsProtocolError, "timed out"):
+                self.make_client(server.base_url, read_timeout=0.05).create_targeting_criterion(
+                    "18ce54d4x5t", "8u94t", "LOCATION", "123"
+                )
+        self.assertEqual(1, len(FakeAdsHandler.requests))
+
+    def test_rejects_oversized_response(self):
+        with FakeAdsServer() as server:
+            FakeAdsHandler.omit_content_length = True
+            FakeAdsHandler.response_body = b"{" + (b"x" * MAX_RESPONSE_BYTES) + b"}"
+            with self.assertRaisesRegex(AdsProtocolError, "response is too large"):
+                self.make_client(server.base_url).create_targeting_criterion(
+                    "18ce54d4x5t", "8u94t", "LOCATION", "123"
+                )
+
+    def test_rejects_declared_oversized_response_before_reading(self):
+        with FakeAdsServer() as server:
+            FakeAdsHandler.response_headers = {
+                "Content-Type": "application/json",
+                "Content-Length": str(MAX_RESPONSE_BYTES + 1),
+            }
+            FakeAdsHandler.response_body = b"{}"
+            with self.assertRaisesRegex(AdsProtocolError, "response is too large"):
+                self.make_client(server.base_url).create_targeting_criterion(
+                    "18ce54d4x5t", "8u94t", "LOCATION", "123"
+                )
+
+    def test_rejects_non_json_response(self):
+        with FakeAdsServer() as server:
+            FakeAdsHandler.response_headers = {"Content-Type": "text/html"}
+            FakeAdsHandler.response_body = b"<html>provider error</html>"
+            with self.assertRaisesRegex(AdsProtocolError, "JSON"):
+                self.make_client(server.base_url).create_targeting_criterion(
+                    "18ce54d4x5t", "8u94t", "LOCATION", "123"
+                )
+
+    def test_rejects_invalid_schema_before_network(self):
+        with FakeAdsServer() as server:
+            client = self.make_client(server.base_url)
+            invalid_cases = [
+                ("../account", "8u94t", "LOCATION", "123"),
+                ("account", "", "LOCATION", "123"),
+                ("account", "line", "location", "123"),
+                ("account", "line", "LOCATION", ""),
+                ("account", "line", "LOCATION", "x" * 1025),
+                ("account", "line", "LOCATION", "value\x00suffix"),
+            ]
+            for values in invalid_cases:
+                with self.subTest(values=values):
+                    with self.assertRaises(AdsProtocolError):
+                        client.create_targeting_criterion(*values)
+        self.assertEqual([], FakeAdsHandler.requests)
+
+    def test_rejects_non_https_non_loopback_endpoint(self):
+        with self.assertRaisesRegex(AdsProtocolError, "HTTPS"):
+            TwitterAdsTargetingClient(
+                consumer_key="key",
+                consumer_secret="secret",
+                access_token="token",
+                access_token_secret="token-secret",
+                base_url="http://example.com/12",
+            )
+
+
+class TargetingFormTests(unittest.TestCase):
+    def test_accepts_exact_utf8_form_schema(self):
+        body = (
+            b"account_id=18ce54d4x5t&line_item_id=8u94t&"
+            b"targeting_type=PHRASE_KEYWORD&targeting_value=grumpy+cat+%E2%98%95"
+        )
+        self.assertEqual(
+            {
+                "account_id": "18ce54d4x5t",
+                "line_item_id": "8u94t",
+                "targeting_type": "PHRASE_KEYWORD",
+                "targeting_value": "grumpy cat ☕",
+            },
+            parse_targeting_form(
+                "POST",
+                "application/x-www-form-urlencoded; charset=UTF-8",
+                body,
+            ),
+        )
+
+    def test_rejects_wrong_method_content_type_size_and_schema(self):
+        valid = (
+            b"account_id=account&line_item_id=line&targeting_type=LOCATION&"
+            b"targeting_value=value"
+        )
+        cases = [
+            ("GET", "application/x-www-form-urlencoded", valid),
+            ("POST", "application/json", valid),
+            ("POST", "application/x-www-form-urlencoded; charset=latin-1", valid),
+            ("POST", "application/x-www-form-urlencoded", b""),
+            ("POST", "application/x-www-form-urlencoded", valid + b"&extra=value"),
+            ("POST", "application/x-www-form-urlencoded", valid + b"&account_id=other"),
+            ("POST", "application/x-www-form-urlencoded", valid.replace(b"LOCATION", b"location")),
+            ("POST", "application/x-www-form-urlencoded", b"x" * (MAX_REQUEST_BYTES + 1)),
+            ("POST", "application/x-www-form-urlencoded", valid + b"%ZZ"),
+        ]
+        for method, content_type, body in cases:
+            with self.subTest(method=method, content_type=content_type, body=body[:80]):
+                with self.assertRaises(AdsProtocolError):
+                    parse_targeting_form(method, content_type, body)
+
+
+class TargetingRequestHandlerTests(unittest.TestCase):
+    class RecordingClient:
+        def __init__(self, error=None):
+            self.error = error
+            self.calls = []
+
+        def create_targeting_criterion(self, **values):
+            self.calls.append(values)
+            if self.error:
+                raise self.error
+            return {"id": "criterion1", "ignored": "provider data"}
+
+    def setUp(self):
+        self.body = (
+            b"account_id=account&line_item_id=line&targeting_type=LOCATION&"
+            b"targeting_value=value"
+        )
+
+    def test_valid_request_calls_provider_once_and_returns_bounded_schema(self):
+        client = self.RecordingClient()
+        status, payload = process_targeting_request(
+            "POST", "application/x-www-form-urlencoded", self.body, lambda: client
+        )
+        self.assertEqual(201, status)
+        self.assertEqual({"valid": True, "id": "criterion1"}, payload)
+        self.assertEqual(
+            [{
+                "account_id": "account",
+                "line_item_id": "line",
+                "targeting_type": "LOCATION",
+                "targeting_value": "value",
+            }],
+            client.calls,
+        )
+
+    def test_invalid_request_never_constructs_client(self):
+        constructed = []
+        status, payload = process_targeting_request(
+            "GET",
+            "application/x-www-form-urlencoded",
+            self.body,
+            lambda: constructed.append(True),
+        )
+        self.assertEqual(400, status)
+        self.assertEqual({"valid": False, "error": "invalid_request"}, payload)
+        self.assertEqual([], constructed)
+
+    def test_provider_error_does_not_expose_raw_details(self):
+        client = self.RecordingClient(
+            AdsProtocolError("provider body contained account names and internal details")
+        )
+        status, payload = process_targeting_request(
+            "POST", "application/x-www-form-urlencoded", self.body, lambda: client
+        )
+        self.assertEqual(502, status)
+        self.assertEqual({"valid": False, "error": "provider_request_failed"}, payload)
+
+    def test_timeout_reports_unknown_outcome_without_retrying(self):
+        client = self.RecordingClient(
+            AdsProtocolError("Twitter Ads request timed out; outcome is unknown", outcome_unknown=True)
+        )
+        status, payload = process_targeting_request(
+            "POST", "application/x-www-form-urlencoded", self.body, lambda: client
+        )
+        self.assertEqual(504, status)
+        self.assertEqual({"valid": False, "error": "provider_outcome_unknown"}, payload)
+        self.assertEqual(1, len(client.calls))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_integration_contracts.py
+++ b/tests/test_integration_contracts.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class IntegrationContractTests(unittest.TestCase):
+    def test_django_endpoint_uses_bounded_protocol_handler(self):
+        source = (ROOT / "home" / "lineitems.py").read_text(encoding="utf-8")
+        required = [
+            "process_targeting_request(",
+            "request.method",
+            "request.META.get(\"CONTENT_TYPE\", \"\")",
+            "request.META.get(\"CONTENT_LENGTH\", \"\")",
+            "MAX_REQUEST_BYTES",
+            "request.body",
+            "TwitterAdsTargetingClient(",
+            "status=status",
+        ]
+        for fragment in required:
+            with self.subTest(fragment=fragment):
+                self.assertIn(fragment, source)
+        self.assertNotIn("TargetingCriteria(account)", source)
+        self.assertNotIn("e.response.body", source)
+
+    def test_browser_uses_csrf_protected_form_posts_with_correct_schema(self):
+        source = (ROOT / "static" / "js" / "ads.js").read_text(encoding="utf-8")
+        required = [
+            'type: "POST"',
+            '"X-CSRFToken": getCookie("csrftoken")',
+            'targeting_type: "CUSTOM_AUDIENCE"',
+            'targeting_type: "PHRASE_KEYWORD"',
+            "line_item_id: line_item_id",
+            "targetingWriteInFlight || payloads.length === 0",
+        ]
+        for fragment in required:
+            with self.subTest(fragment=fragment):
+                self.assertIn(fragment, source)
+        self.assertNotIn("$.getJSON(\"../../ads/api/targeting/new?", source)
+        self.assertNotIn("line_item_id: campaign_id", source)
+        self.assertNotIn("console.log(json)", source)
+
+    def test_current_ads_endpoint_and_transport_are_declared(self):
+        protocol = (ROOT / "home" / "ads_protocol.py").read_text(encoding="utf-8")
+        settings = (ROOT / "app" / "settings.py").read_text(encoding="utf-8")
+        requirements = (ROOT / "requirements.txt").read_text(encoding="utf-8")
+        self.assertIn("HTTPAdapter(max_retries=0)", protocol)
+        self.assertIn("allow_redirects=False", protocol)
+        self.assertIn("timeout=self._timeout", protocol)
+        self.assertIn("https://ads-api.x.com/12", settings)
+        self.assertIn("requests-oauthlib", requirements)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Replaces stale/conflicted #16 after deep protocol review.

## Findings
- #16 does not add a request body; it returns the provider's entire raw error body to the browser.
- The 2016 official SDK already used POST and OAuth 1.0a, but placed write parameters in the query string and had no timeout/redirect/resource controls.
- Current X Ads examples send single targeting-criterion parameters as form data in the POST body.
- The browser used GET for a write, ignored the requested targeting type, passed `campaign_id` as `line_item_id`, and could bind duplicate click handlers.

## Replacement
- CSRF-protected browser POST with strict UTF-8 form schema and 4 KiB request cap.
- OAuth-signed form body, current `/12` endpoint, no redirects, no retries, bounded timeouts, and 64 KiB JSON response cap.
- Generic provider errors only; raw provider bodies and credentials are never returned or logged.
- One in-flight sequential write series; uncertain outcomes require account inspection before manual retry.
- 19 fake-server/contract tests, eight hostile mutations, Python 3.10/3.12/3.14 CI, CodeQL, and changed-tree Gitleaks.

No live provider calls were made.
