### PR TITLE
Support legacy Python targeting form decoding

### DIFF
--- a/home/ads_protocol.py
+++ b/home/ads_protocol.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import json
 import re
+import sys
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -15,6 +16,8 @@ try:
     string_types = (basestring,)
 except NameError:
     string_types = (str,)
+
+PY2 = sys.version_info[0] == 2
 
 
 MAX_REQUEST_BYTES = 4 * 1024
@@ -193,14 +196,24 @@ def parse_targeting_form(method, content_type, body):
     if re.search(br"%(?![0-9A-Fa-f]{2})", body):
         raise AdsProtocolError("targeting request encoding is invalid")
     try:
-        decoded = body.decode("ascii")
-        parsed = parse_qs(
-            decoded,
-            keep_blank_values=True,
-            strict_parsing=True,
-            encoding="utf-8",
-            errors="strict",
-        )
+        if PY2:
+            raw_parsed = parse_qs(body, keep_blank_values=True, strict_parsing=True)
+            parsed = {}
+            for raw_name, raw_values in raw_parsed.items():
+                name = raw_name.decode("ascii") if isinstance(raw_name, bytes) else raw_name
+                parsed[name] = [
+                    value.decode("utf-8") if isinstance(value, bytes) else value
+                    for value in raw_values
+                ]
+        else:
+            decoded = body.decode("ascii")
+            parsed = parse_qs(
+                decoded,
+                keep_blank_values=True,
+                strict_parsing=True,
+                encoding="utf-8",
+                errors="strict",
+            )
     except (UnicodeDecodeError, ValueError, TypeError):
         raise AdsProtocolError("targeting request encoding is invalid")
 

--- a/home/ads_protocol.py
+++ b/home/ads_protocol.py
@@ -8,9 +8,10 @@ import requests
 from requests.adapters import HTTPAdapter
 from requests_oauthlib import OAuth1Session
 try:
-    from urllib.parse import parse_qs, urlsplit
+    from urllib.parse import parse_qs, unquote_to_bytes, urlsplit
 except ImportError:
     from urlparse import parse_qs, urlsplit
+    from urllib import unquote as unquote_to_bytes
 
 try:
     string_types = (basestring,)
@@ -197,14 +198,14 @@ def parse_targeting_form(method, content_type, body):
         raise AdsProtocolError("targeting request encoding is invalid")
     try:
         if PY2:
-            raw_parsed = parse_qs(body, keep_blank_values=True, strict_parsing=True)
             parsed = {}
-            for raw_name, raw_values in raw_parsed.items():
-                name = raw_name.decode("ascii") if isinstance(raw_name, bytes) else raw_name
-                parsed[name] = [
-                    value.decode("utf-8") if isinstance(value, bytes) else value
-                    for value in raw_values
-                ]
+            for pair in body.split(b"&"):
+                if pair.count(b"=") != 1:
+                    raise ValueError("invalid form pair")
+                raw_name, raw_value = pair.split(b"=", 1)
+                name = unquote_to_bytes(raw_name.replace(b"+", b" ")).decode("ascii")
+                value = unquote_to_bytes(raw_value.replace(b"+", b" ")).decode("utf-8")
+                parsed.setdefault(name, []).append(value)
         else:
             decoded = body.decode("ascii")
             parsed = parse_qs(

--- a/tests/test_ads_protocol.py
+++ b/tests/test_ads_protocol.py
@@ -252,6 +252,17 @@ class TargetingFormTests(unittest.TestCase):
             ),
         )
 
+    def test_python2_compatible_decoder_preserves_utf8_schema(self):
+        body = (
+            b"account_id=account&line_item_id=line&targeting_type=PHRASE_KEYWORD&"
+            b"targeting_value=grumpy+cat+%E2%98%95"
+        )
+        with patch("home.ads_protocol.PY2", True):
+            parsed = parse_targeting_form(
+                "POST", "application/x-www-form-urlencoded", body
+            )
+        self.assertEqual("grumpy cat ☕", parsed["targeting_value"])
+
     def test_rejects_wrong_method_content_type_size_and_schema(self):
         valid = (
             b"account_id=account&line_item_id=line&targeting_type=LOCATION&"


### PR DESCRIPTION
Follow-up to #22: preserve the declared Python 2.7 runtime by decoding form fields without Python 3-only `parse_qs` keyword arguments. Adds a compatibility-path UTF-8 test. No provider calls.